### PR TITLE
Fix `list-browser` behavior (closes #2). Some enchasenments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-browser-provider-fbsimctl",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "fbsimctl TestCafe browser provider plugin.",
   "repository": "https://github.com/Ents24/testcafe-browser-provider-fbsimctl",
   "homepage": "https://github.com/Ents24/testcafe-browser-provider-fbsimctl",

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 import parseCapabilities from 'desired-capabilities';
-var childProcess = require('child_process');
+import childProcess from 'child_process';
 
 export default {
     // Multiple browsers support
-    isMultiBrowser: false,
+    isMultiBrowser: true,
 
     currentBrowsers: {},
 
@@ -38,13 +38,14 @@ export default {
     // Browser names handling
     async getBrowserList () {
         var lines = [];
+        var platforms = Object.keys(this.availableDevices).sort();
 
-        for (var device of this.availableDevices) {
-            var line = device.name + ' running on ' + device.sdk;
-
-            lines.push(line);
-        }
-
+        platforms.forEach(platform => {
+            var devicesOnPlatform = this.availableDevices[platform];
+            
+            devicesOnPlatform.forEach(device => lines.push(`fbsimctl:${device.name}:${platform}`));
+        });
+        
         return lines;
     },
 

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ export default {
     async getBrowserList () {
         var devicesList = this._getSortedAvailableDevicesList();
         
-        return devicesList.map(device => `fbsimctl:${device.name}:${device.sdk}`);
+        return devicesList.map(device => `${device.name}:${device.sdk}`);
     },
 
     async isValidBrowserName (browserName) {


### PR DESCRIPTION
I've fixed #2. 

```sh
$ testcafe -b fbsimctl
> "fbsimctl:iPad Retina:iOS 10.2"
> "fbsimctl:iPhone 7 Plus:iOS 10.2"
...
```

And I've added some more changes:
- now devices sorted by iOS version (10.x -> 9.x -> 8.x). It was sorted as strings before (10.x -> 8.x -> 9x)
- if you don't set ios version in arguments (just write `fbsimctl:iphone 6`) it finds all `iphone 6` and run on the latest iOS version

/cc @dig412 