### PR TITLE
Implement alternative emulator waiting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -81,6 +81,7 @@
     "handle-callback-err": "off"
   },
   "env": {
-    "node": true
+    "node": true,
+    "es6": true
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 import parseCapabilities from 'desired-capabilities';
 import childProcess from 'child_process';
+import startSimulator from './start-simulator.js';
+
 
 export default {
     // Multiple browsers support
@@ -20,8 +22,9 @@ export default {
         if (device.state !== 'Shutdown')
             childProcess.execSync('fbsimctl ' + device.udid + ' shutdown', { stdio: 'ignore' });
 
-        childProcess.execSync('fbsimctl ' + device.udid + ' boot', { stdio: 'ignore' });
-        childProcess.execSync('fbsimctl ' + device.udid + ' open ' + pageUrl, { stdio: 'ignore' });
+        await startSimulator(device);
+
+        childProcess.execSync(`xcrun simctl openurl ${device.udid} ${pageUrl}`, { stdio: 'ignore' });
     },
 
     async closeBrowser (id) {

--- a/src/loop-while-true.js
+++ b/src/loop-while-true.js
@@ -1,0 +1,37 @@
+export default function (predicate, interval, timeout = Infinity) { 
+    return new Promise((resolve, reject) => {
+        var timeoutTimer  = null;
+        var intervalTimer = null;
+
+        function clearTimers () {
+            clearInterval(intervalTimer);
+            clearTimeout(timeoutTimer); 
+        }
+
+        function doPredicate () {
+            Promise
+                .resolve(predicate())
+                .then(result => {
+                    if (result)
+                        return;
+
+                    clearTimers();
+                    resolve();
+                })
+                .catch(error => reject(error));
+        }
+
+        intervalTimer = setInterval(doPredicate, interval);
+
+        if (timeout && isFinite(timeout)) {
+            timeoutTimer  = setTimeout(() => {
+                clearTimers();
+                reject(new Error('Loop timeout'));
+            }, timeout);
+
+            timeoutTimer.unref();
+        }
+
+        doPredicate();
+    });
+}

--- a/src/start-simulator.js
+++ b/src/start-simulator.js
@@ -1,0 +1,41 @@
+import { execSync } from 'child_process';
+import path from 'path';
+import loopWhileTrue from './loop-while-true';
+
+
+const XCODE_PATH              = execSync('xcode-select -p').toString().trim();
+const SERVICES_POLL_INTERVAL  = 500;
+const SERVICES_POLL_TIMEOUT   = 15 * 60 * 1000;
+const OPEN_URL_RETRY_INTERVAL = 500;
+
+
+function _isServiceRunning (device) {
+    var versionNumber   = Number(device.sdk.replace('iOS ', ''));
+    var requiredService = versionNumber >= 9 ? 'com.apple.medialibraryd.xpc' : 'com.apple.springboard.carditemscontroller';
+    var simctlCommand   = `xcrun simctl spawn ${device.udid} launchctl print system | grep -q 'A\\s*${requiredService}' && echo up || echo down`;
+
+    return execSync(simctlCommand).toString().trim() === 'up';
+}
+
+export default async function start (device) {
+    var simulatorPath = path.join(XCODE_PATH, 'Applications/Simulator.app');
+
+    execSync(`open ${simulatorPath} --args -CurrentDeviceUDID ${device.udid}`);
+    
+    //Wait until the required services will be started on simulator 
+    await loopWhileTrue(() => !_isServiceRunning(device), SERVICES_POLL_INTERVAL, SERVICES_POLL_TIMEOUT);
+
+    //Sometimes, especially for first boot and last models, there is a time between the services was started,
+    //and the device actually becomes available. So try to open a URL until it will succeed. 
+    await loopWhileTrue(() => {
+        try {
+            //We can't use the test url here, because sometimes it gives the 'Browser was already connected' error.
+            execSync(`xcrun simctl openurl ${device.udid} http://apple.com`, { stdio: 'ignore' });
+        }
+        catch (e) {
+            return true;
+        }
+
+        return false;
+    }, OPEN_URL_RETRY_INTERVAL);
+}


### PR DESCRIPTION
Took a bit more time that I expected, and it's not perfect. Maybe it was just I have macOS inside a VM, but even with `fbsimctl` I've sometimes experienced errors after all required services (SpringBoard, medialibraryd, backboardd) were successfully started. Also I've found that SimulatorBridge, backboardd, and installd are useless because they start very soon after boot, before SpringBoard and medialibraryd services.