### PR TITLE
prevent _getSortedAvailableDevicesList returning array with falsey values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.0.5]
+### Changed
+- @Omonk prevent list of available devices containing null values
+
 ## [0.0.4]
 ### Changed
 - @AndreyBelym fixed boot behaviour, so that the provider properly waits for the Simulator to be ready on all iOS versions

--- a/src/index.js
+++ b/src/index.js
@@ -90,19 +90,13 @@ export default {
     _getSortedAvailableDevicesList () {
         const IOS_REPLACER = 'iOS '; 
 
-        var platformVersions = Object.keys(this.availableDevices)
+        return Object.keys(this.availableDevices)
             .map(device => parseFloat(device.replace(IOS_REPLACER, '')))
-            .sort((a, b) => b - a);
-
-        var list = [];
-
-        platformVersions.forEach(platformVersion => {
-            var devicesOnPlatform = this.availableDevices[`${IOS_REPLACER}${platformVersion}`];
-            
-            list = list.concat(devicesOnPlatform);
-        });
-
-        return list;
+            .sort((a, b) => b - a)
+            .reduce((acc, curr) => {
+                var devicesOnPlatform = this.availableDevices[`${IOS_REPLACER}${curr}`]
+                return devicesOnPlatform ? acc.concat[devicesOnPlatform] : devicesOnPlatform
+            },[]);
     },
 
     _getDeviceFromDetails ({ platform, browserName }) {


### PR DESCRIPTION
I've found using the library that available devices list could contain `null` if `this.availableDevices[`${IOS_REPLACER}${curr}`]` cannot find the correct value. 

This reduce function should aim to stop that.

I've not be able to test locally but hoping this will do the trick